### PR TITLE
Overhaul audio player

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -4,6 +4,6 @@ Built with Next
 
 ## Commands
 
-* Launch Development Server: ``bun/npm run dev``
-* Build for Production: ``bun/npm run build``
-* Launch Production Server: ``bun/npm run prod``
+-   Launch Development Server: `bun/npm run dev`
+-   Build for Production: `bun/npm run build`
+-   Launch Production Server: `bun/npm run prod`

--- a/web/package.json
+++ b/web/package.json
@@ -1,37 +1,39 @@
 {
-    "name": "songscope_web",
-    "version": "0.1.0",
-    "private": true,
-    "scripts": {
-        "dev": "next dev",
-        "devt": "next dev --turbo",
-        "build": "next build",
-        "prod": "next start"
-    },
-    "dependencies": {
-        "@auth/core": "^0.25.0",
-        "body-parser": "^1.20.2",
-        "clsx": "^2.1.0",
-        "dotenv": "^16.4.1",
-        "express": "^4.18.2",
-        "fuse.js": "^7.0.0",
-        "mysql2": "^3.9.1",
-        "next": "^14.1.0",
-        "next-auth": "^4.24.5",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-icons": "^5.0.1",
-        "sharp": "^0.33.2",
-        "spotify-web-api-node": "^5.0.2"
-    },
-    "devDependencies": {
-        "@types/node": "^20.11.15",
-        "@types/react": "^18.2.51",
-        "@types/react-dom": "^18.2.18",
-        "@types/spotify-web-api-node": "^5.0.11",
-        "autoprefixer": "^10.4.17",
-        "postcss": "^8.4.33",
-        "tailwindcss": "^3.4.1",
-        "typescript": "^5.3.3"
-    }
+  "name": "songscope_web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "devt": "next dev --turbo",
+    "build": "next build",
+    "prod": "next start"
+  },
+  "dependencies": {
+    "@auth/core": "^0.25.0",
+    "@wavesurfer/react": "^1.0.4",
+    "body-parser": "^1.20.2",
+    "clsx": "^2.1.0",
+    "dotenv": "^16.4.1",
+    "express": "^4.18.2",
+    "fuse.js": "^7.0.0",
+    "mysql2": "^3.9.1",
+    "next": "^14.1.0",
+    "next-auth": "^4.24.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1",
+    "sharp": "^0.33.2",
+    "spotify-web-api-node": "^5.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.15",
+    "@types/react": "^18.2.51",
+    "@types/react-dom": "^18.2.18",
+    "@types/spotify-web-api-node": "^5.0.11",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.33",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3"
+  }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "songscope_web",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "devt": "next dev --turbo",
-    "build": "next build",
-    "prod": "next start"
-  },
-  "dependencies": {
-    "@auth/core": "^0.25.0",
-    "@wavesurfer/react": "^1.0.4",
-    "body-parser": "^1.20.2",
-    "clsx": "^2.1.0",
-    "dotenv": "^16.4.1",
-    "express": "^4.18.2",
-    "fuse.js": "^7.0.0",
-    "mysql2": "^3.9.1",
-    "next": "^14.1.0",
-    "next-auth": "^4.24.5",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-icons": "^5.0.1",
-    "sharp": "^0.33.2",
-    "spotify-web-api-node": "^5.0.2"
-  },
-  "devDependencies": {
-    "@types/node": "^20.11.15",
-    "@types/react": "^18.2.51",
-    "@types/react-dom": "^18.2.18",
-    "@types/spotify-web-api-node": "^5.0.11",
-    "autoprefixer": "^10.4.17",
-    "postcss": "^8.4.33",
-    "prettier": "^3.2.5",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3"
-  }
+    "name": "songscope_web",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev",
+        "devt": "next dev --turbo",
+        "build": "next build",
+        "prod": "next start"
+    },
+    "dependencies": {
+        "@auth/core": "^0.25.0",
+        "@wavesurfer/react": "^1.0.4",
+        "body-parser": "^1.20.2",
+        "clsx": "^2.1.0",
+        "dotenv": "^16.4.1",
+        "express": "^4.18.2",
+        "fuse.js": "^7.0.0",
+        "mysql2": "^3.9.1",
+        "next": "^14.1.0",
+        "next-auth": "^4.24.5",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
+        "sharp": "^0.33.2",
+        "spotify-web-api-node": "^5.0.2"
+    },
+    "devDependencies": {
+        "@types/node": "^20.11.15",
+        "@types/react": "^18.2.51",
+        "@types/react-dom": "^18.2.18",
+        "@types/spotify-web-api-node": "^5.0.11",
+        "autoprefixer": "^10.4.17",
+        "postcss": "^8.4.33",
+        "prettier": "^3.2.5",
+        "tailwindcss": "^3.4.1",
+        "typescript": "^5.3.3"
+    }
 }

--- a/web/src/components/SideBar.tsx
+++ b/web/src/components/SideBar.tsx
@@ -86,8 +86,8 @@ export default ({variant}: {variant: string}) => {
                 {variant == "profile"
                     ? "User Profile"
                     : variant == "settings"
-                    ? "Settings"
-                    : "Dashboard"}
+                      ? "Settings"
+                      : "Dashboard"}
             </h1>
             <hr className="border-t-2 border-accent-neutral/20 pt-2 pb-1"></hr>
             {variant != "settings" && (
@@ -95,15 +95,15 @@ export default ({variant}: {variant: string}) => {
                     {variant == "profile"
                         ? "Favorite Songs"
                         : variant == "settings"
-                        ? "Config"
-                        : "Top Songs"}
+                          ? "Config"
+                          : "Top Songs"}
                 </h3>
             )}
             {variant == "profile"
                 ? renderProfileBody()
                 : variant == "settings"
-                ? renderSettingsBody()
-                : renderDashboardBody()}
+                  ? renderSettingsBody()
+                  : renderDashboardBody()}
             <hr className="border-t-2 border-accent-neutral/20 mt-auto mb-4"></hr>
             <div className="w-full h-52 flex flex-col mb-4">
                 <div className="my-auto flex flex-col h-full place-content-evenly">

--- a/web/src/components/SongTile.tsx
+++ b/web/src/components/SongTile.tsx
@@ -2,9 +2,15 @@ import Image from "next/image";
 import {IoMdStarHalf} from "react-icons/io";
 import {IoMdStar} from "react-icons/io";
 import {IoMdClose} from "react-icons/io";
-import {IoPlayCircleOutline} from "react-icons/io5";
+import {IoPlayCircleOutline, IoPauseCircleOutline} from "react-icons/io5";
 
-import {useState, useRef, useEffect} from "react";
+import {useWavesurfer} from "@wavesurfer/react";
+
+import {theme} from "../../tailwind.config";
+
+const tailwindColors = theme.extend.colors;
+
+import {useState, useRef, useEffect, useCallback} from "react";
 import clsx from "clsx";
 
 export function Modal({
@@ -56,21 +62,25 @@ interface Review {
 }
 
 function SongInfo({songMetadata, userId}: {songMetadata: any; userId: any}) {
-    const audioRef = useRef<HTMLAudioElement | null>(null);
-    const [audioPlaying, setAudioPlaying] = useState(false);
+    const containerRef = useRef<any>();
 
-    const playAudio = () => {
-        if (audioPlaying) {
-            audioRef.current?.pause();
-        } else {
-            // Check if audioRef.current is not null before accessing its properties
-            if (audioRef.current) {
-                audioRef.current.currentTime = 0;
-                audioRef.current.play();
-            }
-        }
-        setAudioPlaying(!audioPlaying);
+    const {wavesurfer, isReady, isPlaying, currentTime} = useWavesurfer({
+        container: containerRef,
+        url: songMetadata.previewUrl,
+        waveColor: tailwindColors.secondary,
+        progressColor: tailwindColors.primary,
+        dragToSeek: true,
+        height: "auto",
+        barWidth: 1.5,
+        barGap: 1,
+        barRadius: 5,
+        cursorColor: tailwindColors.accent.neutral
+    });
+
+    const onPlayPause = () => {
+        wavesurfer && wavesurfer.playPause();
     };
+
     const [reviewText, setReviewText] = useState("");
     // TODO: Beautify the datetime returned and format it in human-readable format
     const [reviews, setReviews] = useState<Review[]>([]);
@@ -128,7 +138,7 @@ function SongInfo({songMetadata, userId}: {songMetadata: any; userId: any}) {
 
     return (
         <div className="flex flex-row h-full divide-x divide-accent-neutral/20 space-x-8">
-            <div className="flex flex-col place-content-between h-full w-2/5">
+            <div className="flex flex-col place-content-between h-full w-2/5 overflow-scroll">
                 <div>
                     <Image
                         src={songMetadata.albumArtUrl}
@@ -181,57 +191,24 @@ function SongInfo({songMetadata, userId}: {songMetadata: any; userId: any}) {
                     </div>
                 </div>
                 {songMetadata.previewUrl && (
-                    // TODO --> Replace this with a custom audio player that shifts and allows users to seek through the preview
                     // Would be cool to have users able to link to certain parts of the song within comments
-                    <div className="flex flex-row space-x-2 mt-auto mb-2">
-                        <div className="w-40 h-8 relative">
-                            <div className="w-40 h-px left-0 top-[15.81px] absolute border border-rose-700"></div>
-                            <div className="w-4 h-px left-[3px] top-[8.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[7px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[11px] top-[9.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[16px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-8 h-px left-[20px] top-0 absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[24px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[50px] top-[9.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[45px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[40px] top-[9.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[35px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-8 h-px left-[30px] top-0 absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[25px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[52px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[55px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[58px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[61px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[64px] top-[3.96px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[68px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[87px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[83px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[79px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[76px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[72px] top-[3.96px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[128px] top-[9.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[133px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[139px] top-[9.90px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[145px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-8 h-px left-[150px] top-0 absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[156px] top-[5.94px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[126px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[122px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[119px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[115px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[112px] top-[3.96px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[107px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[86px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-4 h-px left-[91px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-3 h-px left-[95px] top-[11.88px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-5 h-px left-[98px] top-[8.91px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                            <div className="w-6 h-px left-[103px] top-[3.96px] absolute origin-top-left rotate-90 border border-rose-700"></div>
-                        </div>
-                        <audio ref={audioRef} src={songMetadata.previewUrl} />
-                        <IoPlayCircleOutline
-                            className="text-3xl my-auto text-rose-700 hover:cursor-pointer"
-                            onClick={playAudio}
-                        />
+                    <div className="flex flex-row space-x-2 mt-auto mb-2 pt-2">
+                        {/* Look into adding in timestamps later... */}
+                        {/* <div> */}
+                        <div className="w-40 h-8 relative" ref={containerRef} />
+                        {/* <p className="absolute bottom-1 text-sm italic text-accent-neutral/70">{currentTime.toFixed(0)} : {wavesurfer?.getDuration().toFixed(0)}</p> */}
+                        {/* </div> */}
+                        {isPlaying ? (
+                            <IoPauseCircleOutline
+                                className="text-3xl my-auto text-rose-700 hover:cursor-pointer"
+                                onClick={onPlayPause}
+                            />
+                        ) : (
+                            <IoPlayCircleOutline
+                                className="text-3xl my-auto text-rose-700 hover:cursor-pointer"
+                                onClick={onPlayPause}
+                            />
+                        )}
                     </div>
                 )}
             </div>

--- a/web/src/pages/_document.tsx
+++ b/web/src/pages/_document.tsx
@@ -1,6 +1,6 @@
 import {Html, Head, Main, NextScript} from "next/document";
 
-export default (): JSX.Element =>  {
+export default (): JSX.Element => {
     return (
         <Html lang="en">
             <Head />
@@ -10,4 +10,4 @@ export default (): JSX.Element =>  {
             </body>
         </Html>
     );
-}
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,7 @@
 {
     "compilerOptions": {
         "target": "ESNext",
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "esnext"
-        ],
+        "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
         "strict": true,
@@ -18,17 +14,9 @@
         "isolatedModules": true,
         "jsx": "preserve",
         "paths": {
-            "@/*": [
-                "./src/*"
-            ]
-        },
+            "@/*": ["./src/*"]
+        }
     },
-    "include": [
-        "next-env.d.ts",
-        "**/*.ts",
-        "**/*.tsx"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR aims to improve upon the audio visualizer we have for the song previews. Currently, it's just a series of really bad boxes that aim to mimic what a waveform visual would look like. 

As of this PR, waveforms are now custom to each preview (although the scaling on them _could_ still be improved), and we now support seeking by clicking on specific parts of the preview wave.