### PR TITLE
Allow Dual Provider Auth to Same Account

### DIFF
--- a/web/src/components/ConnectionEntry.tsx
+++ b/web/src/components/ConnectionEntry.tsx
@@ -1,16 +1,22 @@
+import {signIn} from "next-auth/react";
+
 /*
 For connections with different providers like Spotify and Google
 */
 
-export default ({
+export default function ConnectionEntry({
     providerName,
-    isConnected,
-    onToggle
+    isConnected
 }: {
     providerName: string;
     isConnected: boolean;
-    onToggle: () => void;
-}): JSX.Element => {
+}): JSX.Element {
+    const handleConnect = () => {
+        if (!isConnected) {
+            signIn(providerName.toLowerCase());
+        }
+    };
+
     return (
         <>
             <span>{providerName}</span>
@@ -18,11 +24,12 @@ export default ({
                 className={`px-3 py-1.5 ml-1.5 rounded-full font-semibold transition-all ${
                     isConnected ? "bg-green-600 hover:bg-green-700" : "bg-red-700 hover:bg-red-800"
                 } text-white`}
-                onClick={onToggle}
+                onClick={handleConnect}
+                disabled={isConnected}
             >
                 {isConnected ? "Connected" : "Connect"}
             </button>
             <br></br>
         </>
     );
-};
+}

--- a/web/src/components/ConnectionEntry.tsx
+++ b/web/src/components/ConnectionEntry.tsx
@@ -4,13 +4,13 @@ import {signIn} from "next-auth/react";
 For connections with different providers like Spotify and Google
 */
 
-export default function ConnectionEntry({
+export default ({
     providerName,
-    isConnected,
+    isConnected
 }: {
     providerName: string;
     isConnected: boolean;
-}): JSX.Element {
+}): JSX.Element => {
     const handleConnect = () => {
         if (!isConnected) {
             signIn(providerName.toLowerCase(), {callbackUrl: "/settings"});
@@ -32,4 +32,4 @@ export default function ConnectionEntry({
             <br></br>
         </>
     );
-}
+};

--- a/web/src/components/ConnectionEntry.tsx
+++ b/web/src/components/ConnectionEntry.tsx
@@ -6,14 +6,14 @@ For connections with different providers like Spotify and Google
 
 export default function ConnectionEntry({
     providerName,
-    isConnected
+    isConnected,
 }: {
     providerName: string;
     isConnected: boolean;
 }): JSX.Element {
     const handleConnect = () => {
         if (!isConnected) {
-            signIn(providerName.toLowerCase());
+            signIn(providerName.toLowerCase(), {callbackUrl: "/settings"});
         }
     };
 

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -188,20 +188,8 @@ export default ({
                         <h2 className="text-2xl font-bold pt-6 pb-2 flex flex-row">
                             <MdLink className="my-auto text-xl mr-3" /> Connections
                         </h2>
-                        <ConnectionEntry
-                            providerName="Spotify"
-                            isConnected={connections.spotify}
-                            onToggle={() => {
-                                /* Replace with actual function */
-                            }}
-                        />
-                        <ConnectionEntry
-                            providerName="Google"
-                            isConnected={connections.google}
-                            onToggle={() => {
-                                /* Replace with actual function */
-                            }}
-                        />
+                        <ConnectionEntry providerName="Spotify" isConnected={connections.spotify} />
+                        <ConnectionEntry providerName="Google" isConnected={connections.google} />
                     </div>
                     <h2 className="text-2xl font-bold pt-6 pb-2 flex flex-row">
                         <MdOutlineSecurity className="my-auto text-xl mr-3" />


### PR DESCRIPTION
Users are now able to sign in with one provider, connect another provider, and then use either providers (both google and spotify) to sign in to the same account. If a user does this, they will be able to see two connected indicators for both of their providers on the platform. 

<img width="823" alt="image" src="https://github.com/timrolsh/Songscope/assets/68395794/1efbaded-bd60-4e48-adf5-bcf5a457a9ac">
